### PR TITLE
ci: schedule docker workflow

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
   schedule:
-    - cron: '0 0 * * 0'
+    - cron: '47 13 * * 2'
 
 
 jobs:

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  schedule:
+    - cron: '0 0 * * 0'
+
 
 jobs:
   build:


### PR DESCRIPTION
To build on new baseimage

Looks like debian build round about every two weeks a new image